### PR TITLE
Allow Get data from Show my trades

### DIFF
--- a/IqOptionApi.sln
+++ b/IqOptionApi.sln
@@ -1,19 +1,23 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sample", "Sample", "{254AA6AE-687A-4F41-9637-7F1D89533DC4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IqOptionApi.Samples", "Sample\IqOptionApi.Samples\IqOptionApi.Samples.csproj", "{F980D376-4C0E-4248-B77F-B6D1015C0244}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IqOptionApi.Samples", "Sample\IqOptionApi.Samples\IqOptionApi.Samples.csproj", "{F980D376-4C0E-4248-B77F-B6D1015C0244}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IqOptionApi.NET", "src\IqOptionApi.NET\IqOptionApi.NET.csproj", "{925CAFCB-016F-407C-869A-3DA9A1157946}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IqOptionApi.NET", "src\IqOptionApi.NET\IqOptionApi.NET.csproj", "{925CAFCB-016F-407C-869A-3DA9A1157946}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IqOptionApi.Tests", "tests\IqOptionApi.Tests\IqOptionApi.Tests.csproj", "{72988539-D915-4DBA-909A-A99C121ADF04}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IqOptionApi.Tests", "tests\IqOptionApi.Tests\IqOptionApi.Tests.csproj", "{72988539-D915-4DBA-909A-A99C121ADF04}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{900633CE-8D1B-43E6-BEC7-9942E75610F8}"
 EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F980D376-4C0E-4248-B77F-B6D1015C0244}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F980D376-4C0E-4248-B77F-B6D1015C0244}.Debug|Any CPU.Build.0 = Debug|Any CPU
@@ -28,12 +32,14 @@ Global
 		{72988539-D915-4DBA-909A-A99C121ADF04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72988539-D915-4DBA-909A-A99C121ADF04}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F980D376-4C0E-4248-B77F-B6D1015C0244} = {254AA6AE-687A-4F41-9637-7F1D89533DC4}
 		{72988539-D915-4DBA-909A-A99C121ADF04} = {900633CE-8D1B-43E6-BEC7-9942E75610F8}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7DE28C24-83E9-47FD-BB1A-758619A28619}
 	EndGlobalSection
 EndGlobal

--- a/Sample/IqOptionApi.Samples/SampleRunners/SubscribeLiveDealSample.cs
+++ b/Sample/IqOptionApi.Samples/SampleRunners/SubscribeLiveDealSample.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IqOptionApi.Models;
+using IqOptionApi.Models.DigitalOptions;
+using IqOptionApi.Ws.Base;
+
+namespace IqOptionApi.Samples.SampleRunners
+{
+    public class SubscribeLiveDealSample : SampleRunner
+    {
+        
+
+        public override async Task RunSample()
+        {
+            
+            if (await IqClientApi.ConnectAsync())
+            {
+                // subscribe to pair to get real-time data for tf1min and tf5min
+                IqClientApi.SubscribeLiveDeal("live-deal-digital-option", ActivePair.EURUSD, DigitalOptionsExpiryType.PT1M);
+                IqClientApi.SubscribeLiveDeal("live-deal-digital-option", ActivePair.EURUSD, DigitalOptionsExpiryType.PT5M);
+
+                // call the subscribe to listening when mood changed
+                IqClientApi.WsClient.LiveDealObservable().Subscribe(x => {
+
+                    // values goes here
+                    _logger.Information(
+                        $"Lives User Id: {x.UserId} Created {x.CreatedAt} Amount: {x.AmountEnrolled} Direction: {x.InstrumentDir}"
+                    );
+
+                });
+
+                // hold 2 secs
+                Thread.Sleep(2000);
+
+                // after this line no-more realtime data for min5 print on console
+                IqClientApi.UnSubscribeLiveDeal("live-deal-digital-option", ActivePair.EURUSD, DigitalOptionsExpiryType.PT1M);
+                IqClientApi.UnSubscribeLiveDeal("live-deal-digital-option", ActivePair.EURUSD, DigitalOptionsExpiryType.PT5M);
+            }
+        }
+    }
+}

--- a/src/IqOptionApi.NET/IIqOptionClient.cs
+++ b/src/IqOptionApi.NET/IIqOptionClient.cs
@@ -41,6 +41,17 @@ namespace IqOptionApi
         /// </summary>
         void UnSubscribeTradersMoodChanged(InstrumentType instrumentType, ActivePair active);
 
+        /// <summary>
+        /// Subscribe live deal
+        /// </summary>
+        void SubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration);
+
+        /// <summary>
+        /// Unsubscribe live deal
+        /// </summary>
+        void UnSubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration);
+
+
         #endregion
 
         #region PlacePositionCommands

--- a/src/IqOptionApi.NET/IqOptionClient.cs
+++ b/src/IqOptionApi.NET/IqOptionClient.cs
@@ -140,6 +140,15 @@ namespace IqOptionApi
         public Task<DigitalOptionsPlacedResult> PlaceDigitalOptions(string instrumentId, double amount)
             => WsClient?.PlaceDigitalOptions(instrumentId, amount);
 
+        /// <inheritdoc/>
+        public void SubscribeLiveDeal(String message, ActivePair pair, DigitalOptionsExpiryType duration)
+            => WsClient?.SubscribeLiveDeal(message, pair, duration);
+
+        /// <inheritdoc/>
+        public void UnSubscribeLiveDeal(String message, ActivePair pair, DigitalOptionsExpiryType duration)
+            => WsClient?.UnSubscribeLiveDeal(message, pair, duration);
+
+
         public void Dispose()
         {
             connectedSubject?.Dispose();

--- a/src/IqOptionApi.NET/Models/DigitalOptions/OptionExpiryType.cs
+++ b/src/IqOptionApi.NET/Models/DigitalOptions/OptionExpiryType.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Serialization;
+
+namespace IqOptionApi.Models.DigitalOptions
+{
+    /// <summary>
+    /// The expiration periods to place the position of Options
+    /// </summary>
+    public enum DigitalOptionsExpiryType
+    {
+        [EnumMember(Value = "1M")]
+        PT1M = 1,
+        
+        [EnumMember(Value = "5M")]
+        PT5M = 5,
+        
+        [EnumMember(Value = "15M")]
+        PT15M = 15
+    }
+}

--- a/src/IqOptionApi.NET/Models/LiveDeal.cs
+++ b/src/IqOptionApi.NET/Models/LiveDeal.cs
@@ -1,0 +1,52 @@
+using IqOptionApi.Converters.JsonConverters;
+using IqOptionApi.Utilities;
+using Newtonsoft.Json;
+using System;
+
+namespace IqOptionApi.Models
+{
+    public class LiveDeal
+    {
+
+        [JsonProperty("amount_enrolled")]
+        public double AmountEnrolled { get; set; }
+
+        [JsonProperty("avatar")]
+        public string Avatar { get; set; }
+
+        [JsonProperty("created_at")]
+        [JsonConverter(typeof(UnixDateTimeJsonConverter))]
+        public DateTimeOffset? CreatedAt { get; set; }
+
+        [JsonProperty("expiration_type")]
+        public string ExpirationType { get; set; }
+
+        [JsonProperty("flag")]
+        public string Flag { get; set; }
+
+        [JsonProperty("instrument_active_id")]
+        public ActivePair ActiveId { get; set; }
+
+        [JsonProperty("instrument_dir")]
+        public string InstrumentDir { get; set; }
+
+        [JsonProperty("instrument_expiration")]
+        public string InstrumentExpiration { get; set; }
+
+        [JsonProperty("is_big")]
+        public string IsBig { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("position_id")]
+        public long PositionId { get; set; }
+
+        [JsonProperty("user_id")] 
+        public long UserId { get; set; }
+
+        [JsonProperty("brand_id")]
+        public long BrandId { get; set; }
+
+    }
+}

--- a/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/SubscribeLiveDealRequest.cs
+++ b/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/SubscribeLiveDealRequest.cs
@@ -1,0 +1,29 @@
+using IqOptionApi.Models;
+using IqOptionApi.Models.DigitalOptions;
+using IqOptionApi.Utilities;
+using IqOptionApi.Ws.Base;
+
+namespace IqOptionApi.Wss.Request.SubscribeMessages
+{
+    internal class SubscribeLiveDealRequest : WsMessageBase<dynamic>
+    {
+        public override string Name => "subscribeMessage";
+
+        public SubscribeLiveDealRequest(string message, ActivePair pair, DigitalOptionsExpiryType duration)
+        {
+            base.Message = new
+            {
+                name = message,
+                @params =
+                    new {
+                        routingFilters =
+                            new
+                            {
+                                instrument_active_id = (int) pair,
+                                expiration_type = duration.ToString()
+                            }
+                    }
+            };
+        }
+    }
+}

--- a/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/UnsubscribeLiveDealRequest.cs
+++ b/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/UnsubscribeLiveDealRequest.cs
@@ -12,7 +12,6 @@ namespace IqOptionApi.Wss.Request.SubscribeMessages
         public UnsubscribeLiveDealRequest(string message, ActivePair pair, DigitalOptionsExpiryType duration)
         {
             
-
             base.Message = new
             {
                 name = message,

--- a/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/UnsubscribeLiveDealRequest.cs
+++ b/src/IqOptionApi.NET/Wss/Request/SubscribeMessages/UnsubscribeLiveDealRequest.cs
@@ -1,0 +1,32 @@
+using IqOptionApi.Models;
+using IqOptionApi.Models.DigitalOptions;
+using IqOptionApi.Utilities;
+using IqOptionApi.Ws.Base;
+
+namespace IqOptionApi.Wss.Request.SubscribeMessages
+{
+    internal class UnsubscribeLiveDealRequest : WsMessageBase<dynamic>
+    {
+        public override string Name => "unsubscribeMessage";
+
+        public UnsubscribeLiveDealRequest(string message, ActivePair pair, DigitalOptionsExpiryType duration)
+        {
+            
+
+            base.Message = new
+            {
+                name = message,
+                @params =
+                    new
+                    {
+                        routingFilters =
+                            new
+                            {
+                                instrument_active_id = (int) pair,
+                                expiration_type = duration
+                            }
+                    }
+            };
+        }
+    }
+}

--- a/src/IqOptionApi.NET/Wss/Subscribes/LiveDealSubscribe.cs
+++ b/src/IqOptionApi.NET/Wss/Subscribes/LiveDealSubscribe.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using IqOptionApi.Models;
+using IqOptionApi.Models.DigitalOptions;
+using IqOptionApi.utilities;
+using IqOptionApi.Ws.Base;
+using IqOptionApi.Wss.Request.SubscribeMessages;
+
+// ReSharper disable once CheckNamespace
+namespace IqOptionApi.Ws
+{
+    public partial class IqOptionWebSocketClient
+    {
+        private readonly Subject<LiveDeal> _livedealSubject = new Subject<LiveDeal>();
+        public IObservable<LiveDeal> LiveDealObservable() => _livedealSubject.AsObservable();
+
+        [SubscribeForTopicName(MessageType.LiveDealDigitalOption, typeof(LiveDeal))]
+        public void Subscribe(LiveDeal value)
+        {
+            _livedealSubject.OnNext(value);
+        }
+        
+        /// <summary>
+        /// Subscribe to Traders mood changed
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="pair"></param>
+        public void SubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration)
+        {
+            SendMessageAsync(new SubscribeLiveDealRequest(message, pair, duration), "s_").ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// UnSubscribe to Traders mood changed
+        /// </summary>
+        /// <param name="type">The Instrument type.</param>
+        /// <param name="pair">The Active pair</param>
+        public void UnSubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration)
+        {
+            SendMessageAsync(new UnsubscribeLiveDealRequest(message, pair, duration), "s_").ConfigureAwait(false);
+        }
+    }
+}

--- a/src/IqOptionApi.NET/Wss/Subscribes/LiveDealSubscribe.cs
+++ b/src/IqOptionApi.NET/Wss/Subscribes/LiveDealSubscribe.cs
@@ -20,22 +20,24 @@ namespace IqOptionApi.Ws
         {
             _livedealSubject.OnNext(value);
         }
-        
+
         /// <summary>
-        /// Subscribe to Traders mood changed
+        /// Subscribe to to Live Deal
         /// </summary>
-        /// <param name="type"></param>
+        /// <param name="message"></param>
         /// <param name="pair"></param>
+        /// <param name="duration"></param>
         public void SubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration)
         {
             SendMessageAsync(new SubscribeLiveDealRequest(message, pair, duration), "s_").ConfigureAwait(false);
         }
 
         /// <summary>
-        /// UnSubscribe to Traders mood changed
+        /// UnSubscribe to Live Deal
         /// </summary>
-        /// <param name="type">The Instrument type.</param>
-        /// <param name="pair">The Active pair</param>
+        /// <param name="message">The Instrument type.</param>
+        /// <param name="pair">The Instrument type.</param>
+        /// <param name="duration">The Active pair</param>
         public void UnSubscribeLiveDeal(string message, ActivePair pair, DigitalOptionsExpiryType duration)
         {
             SendMessageAsync(new UnsubscribeLiveDealRequest(message, pair, duration), "s_").ConfigureAwait(false);

--- a/src/IqOptionApi.NET/Wss/base/MessageType.cs
+++ b/src/IqOptionApi.NET/Wss/base/MessageType.cs
@@ -32,5 +32,10 @@ namespace IqOptionApi.Ws.Base
 
         public const string PlacedDigitalOptions = "digital-option-placed";
         public const string PlacedBinaryOptions = "option";
+
+        public const string LiveDealDigitalOption = "live-deal-digital-option";
+
+        public const string LiveDealBinaryOption = "live-deal-binary-option-placed";
+
     }
 }


### PR DESCRIPTION
By signing the live-deal-digital-option option, I can capture when a user opens a new entry afterwards, just deal with it.

![image](https://user-images.githubusercontent.com/5083403/88533854-4c1e5600-cfdd-11ea-8aa0-8e035e9a40cb.png)

I'm sorry, because I'm in Brazil my account is in Portuguese and the image I couldn't translate into English
